### PR TITLE
fix: ensure flash messages are always shared to prevent persistence on refresh

### DIFF
--- a/packages/inertia-sails/lib/middleware/inertia-middleware.js
+++ b/packages/inertia-sails/lib/middleware/inertia-middleware.js
@@ -1,28 +1,17 @@
-const isInertiaRequest = require('../helpers/is-inertia-request')
-
 const resolveValidationErrors = require('../helpers/resolve-validation-errors')
 function inertia(hook) {
   return function inertiaMiddleware(req, res, next) {
-    // Always consume flash messages to prevent persistence after refresh
-    // This matches the behavior of validation errors which are always consumed
     const flash = {
       message: req.flash('message'),
       error: req.flash('error'),
       success: req.flash('success')
     }
 
-    // Only share flash messages and validation errors if this is an Inertia request
-    if (isInertiaRequest(req)) {
-      hook.share('flash', flash)
+    hook.share('flash', flash)
 
-      const validationErrors = resolveValidationErrors(req)
-      req.flash('errors', validationErrors)
-
-      hook.share('errors', req.flash('errors')[0] || {})
-    }
-    // Note: Flash messages are consumed regardless of request type
-    // This ensures they don't persist after manual page refresh (F5)
-
+    const validationErrors = resolveValidationErrors(req)
+    req.flash('errors', validationErrors)
+    hook.share('errors', req.flash('errors')[0] || {})
     return next()
   }
 }

--- a/packages/inertia-sails/lib/middleware/inertia-middleware.js
+++ b/packages/inertia-sails/lib/middleware/inertia-middleware.js
@@ -3,12 +3,16 @@ const isInertiaRequest = require('../helpers/is-inertia-request')
 const resolveValidationErrors = require('../helpers/resolve-validation-errors')
 function inertia(hook) {
   return function inertiaMiddleware(req, res, next) {
+    // Always consume flash messages to prevent persistence after refresh
+    // This matches the behavior of validation errors which are always consumed
+    const flash = {
+      message: req.flash('message'),
+      error: req.flash('error'),
+      success: req.flash('success')
+    }
+
+    // Only share flash messages and validation errors if this is an Inertia request
     if (isInertiaRequest(req)) {
-      const flash = {
-        message: req.flash('message'),
-        error: req.flash('error'),
-        success: req.flash('success')
-      }
       hook.share('flash', flash)
 
       const validationErrors = resolveValidationErrors(req)
@@ -16,6 +20,8 @@ function inertia(hook) {
 
       hook.share('errors', req.flash('errors')[0] || {})
     }
+    // Note: Flash messages are consumed regardless of request type
+    // This ensures they don't persist after manual page refresh (F5)
 
     return next()
   }


### PR DESCRIPTION
Resolves #139 

## Problem

Flash messages were persisting in the UI after page refreshes (F5) because they were being consumed on every request but only shared with the Inertia hook on Inertia requests. When a user refreshed the page with F5, it would make a non-Inertia request, consume the flash messages from the session, but never share them with the hook to clear them from the frontend state.

## Solution

Always share flash messages and validation errors with the Inertia hook regardless of request type. This ensures:

- Flash messages are consumed on every request ✅  
- Flash messages are always shared with the hook ✅
- The hook can properly handle clearing them from the frontend state ✅
- Consistent behavior for both Inertia requests and regular page refreshes ✅

## Changes

- Removed the `if (isInertiaRequest(req))` condition in the inertia middleware
- Flash messages and validation errors are now always processed and shared
- Minimal performance impact with significant reliability improvement

## Testing

- [x] Flash messages are cleared on page refresh
- [x] Flash messages work normally with Inertia navigation  
- [x] No breaking changes to existing functionality