### PR TITLE
feat: optimize dev watch to only restart on api and config changes

### DIFF
--- a/templates/ascent-react/package.json
+++ b/templates/ascent-react/package.json
@@ -57,7 +57,7 @@
     "tailwindcss": "^3.4.17"
   },
   "scripts": {
-    "dev": "node --watch app.js",
+    "dev": "node --watch-path=api --watch-path=config app.js",
     "start": "NODE_ENV=production node app.js",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",

--- a/templates/mellow-react/package.json
+++ b/templates/mellow-react/package.json
@@ -34,7 +34,7 @@
     "tailwindcss": "^4.1.16"
   },
   "scripts": {
-    "dev": "node --watch app.js",
+    "dev": "node --watch-path=api --watch-path=config app.js",
     "start": "NODE_ENV=production node app.js",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",

--- a/templates/mellow-svelte/package.json
+++ b/templates/mellow-svelte/package.json
@@ -37,7 +37,7 @@
     "tailwindcss": "^4.1.16"
   },
   "scripts": {
-    "dev": "node --watch app.js",
+    "dev": "node --watch-path=api --watch-path=config app.js",
     "start": "NODE_ENV=production node app.js",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",


### PR DESCRIPTION
Resolves #123

This PR optimizes the `npm run dev` command to only watch and restart the server when changes are made to `api/` and `config/` folders.

## Changes
- Updated dev script to use `--watch-path=api --watch-path=config`
- Assets changes are handled by HMR (no server restart needed)
- View changes require manual page refresh (no server restart needed)

## Benefits
- Reduces unnecessary server restarts during development
- Provides Rails-like DX with automatic backend code reloading
- Improves development performance