### PR TITLE
fix: skip Inertia middleware for WebSocket requests

### DIFF
--- a/packages/inertia-sails/lib/middleware/inertia-middleware.js
+++ b/packages/inertia-sails/lib/middleware/inertia-middleware.js
@@ -1,6 +1,12 @@
 const resolveValidationErrors = require('../helpers/resolve-validation-errors')
 function inertia(hook) {
   return function inertiaMiddleware(req, res, next) {
+    // Skip Inertia middleware for WebSocket requests
+    // WebSocket requests don't have req.flash() and don't need Inertia rendering
+    if (req.isSocket) {
+      return next()
+    }
+
     const flash = {
       message: req.flash('message'),
       error: req.flash('error'),


### PR DESCRIPTION
Fixes #165 

WebSocket requests in Sails don't have req.flash() available, causing the Inertia middleware to crash. This change adds a guard to skip the middleware for socket requests since they don't need Inertia rendering (they return JSON, not HTML).