### PR TITLE
feat(inertia-sails): set up AsyncLocalStorage context early in routes…

### DIFF
--- a/packages/inertia-sails/lib/middleware/inertia-middleware.js
+++ b/packages/inertia-sails/lib/middleware/inertia-middleware.js
@@ -2,39 +2,29 @@ const resolveValidationErrors = require('../helpers/resolve-validation-errors')
 const requestContext = require('../helpers/request-context')
 
 /**
- * Inertia middleware that handles validation errors and request context.
+ * Inertia middleware that handles validation errors.
  *
- * Uses AsyncLocalStorage to make the request available throughout the
- * request lifecycle without explicitly passing it.
+ * Note: AsyncLocalStorage context is set up earlier in routes.before
+ * (see index.js) so that other hooks can use sails.inertia.share()
+ * with proper request context.
  *
- * This enables request-scoped features:
- * - sails.inertia.share() - Per-request shared props (prevents data leaking between users)
- * - sails.inertia.flash() - Per-request flash messages
- * - sails.inertia.encryptHistory() - Per-request history encryption
- * - sails.inertia.clearHistory() - Per-request history clearing
+ * This middleware handles:
+ * - Validation errors from redirects (shared as 'errors' prop)
  *
  * @param {Object} hook - The inertia-sails hook instance
  * @returns {Function} Express/Sails middleware function
  */
 function inertia(hook) {
   return function inertiaMiddleware(req, res, next) {
-    // Skip Inertia middleware for WebSocket requests
-    if (req.isSocket) {
-      return next()
-    }
+    // Skip for WebSocket requests (they don't have req.flash)
+    if (req.isSocket) return next()
 
-    // Wrap the rest of the request in AsyncLocalStorage context
-    // This makes req/res and request-scoped data available anywhere
-    requestContext.run(req, res, () => {
-      // Handle validation errors - share them for this request only
-      const validationErrors = resolveValidationErrors(req)
-      req.flash('errors', validationErrors)
-
-      // Share errors for this request (request-scoped, not global)
-      requestContext.setSharedProp('errors', req.flash('errors')[0] || {})
-
-      return next()
-    })
+    // Handle validation errors - share them for this request only
+    // Context is already set up by routes.before in index.js
+    const validationErrors = resolveValidationErrors(req)
+    req.flash('errors', validationErrors)
+    requestContext.setSharedProp('errors', req.flash('errors')[0] || {})
+    return next()
   }
 }
 


### PR DESCRIPTION
….before

Move AsyncLocalStorage context setup from middleware to routes.before so that other Sails hooks can use sails.inertia.share() with proper request-scoped context.

This fixes the issue where hooks calling share() would fall back to global storage (causing race conditions) because hooks run before middleware.

Closes #180