### PR TITLE
feat: add rich Boring Stack error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boring-stack",
-  "version": "1.2.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boring-stack",
-      "version": "1.2.3",
+      "version": "1.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -456,6 +456,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
+    },
     "node_modules/@sailshq/csurf": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@sailshq/csurf/-/csurf-1.11.1.tgz",
@@ -538,6 +576,24 @@
       "integrity": "sha512-c0t+KCuUkO/YDLPG4WWzEwx3J5F/GHXsD1h/SNZfySqAIKe/BaP95x8fWtOfRJokpS5yYHRJjMtYlXD8jxnpbw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -1398,6 +1454,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -1703,6 +1765,15 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -2930,6 +3001,15 @@
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lilconfig": {
@@ -6227,6 +6307,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
     "packages/create-sails": {
       "version": "1.2.1",
       "license": "MIT",
@@ -6253,9 +6356,11 @@
       }
     },
     "packages/inertia-sails": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
-      "devDependencies": {},
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boring-stack",
-  "version": "1.2.3",
+  "version": "1.5.0",
   "private": "true",
   "description": "The Boring JavaScript Stack 🥱 - an opinionated project starter for fullstack JavaScript",
   "scripts": {

--- a/packages/inertia-sails/README.md
+++ b/packages/inertia-sails/README.md
@@ -194,6 +194,76 @@ sails.inertia.flash({ error: 'Failed', field: 'email' })
 
 Access in your frontend via `page.props.flash`.
 
+### Error Pages
+
+In development, 500-level HTML responses render a rich Youch error page with
+the stack trace and sanitized request metadata. For Inertia visits, the client
+will show that HTML in its development error modal.
+
+In production, `inertia-sails` renders the configured Inertia error page for
+`403`, `404`, `500`, and `503` responses by default. The page receives
+`status`, `title`, and `message` props:
+
+```vue
+<!-- assets/js/pages/error.vue -->
+<script setup>
+import { Head, Link } from '@inertiajs/vue3'
+
+defineProps({
+  status: Number,
+  title: String,
+  message: String
+})
+</script>
+
+<template>
+  <Head :title="`${status} ${title}`" />
+
+  <main>
+    <p>Status {{ status }}</p>
+    <h1>{{ title }}</h1>
+    <p>{{ message }}</p>
+    <Link href="/">Go home</Link>
+  </main>
+</template>
+```
+
+Wire Sails' standard responses through the hook so framework-level 403/404/500
+responses use the same policy:
+
+```js
+// api/responses/serverError.js
+module.exports = function serverError(error) {
+  return this.req._sails.inertia.handleServerError(this.req, this.res, error)
+}
+
+// api/responses/notFound.js
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}
+
+// api/responses/forbidden.js
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}
+```
+
+Hybrid apps can keep classic Sails EJS error views by disabling the Inertia
+error page:
+
+```js
+// config/inertia.js
+module.exports.inertia = {
+  errorPage: false
+}
+```
+
 ### Precognition
 
 Inertia v3 forms can validate against server-owned Sails rules before the real
@@ -480,6 +550,8 @@ Copy these to `api/responses/`:
 - **inertiaRedirect.js** - Handle Inertia redirects
 - **badRequest.js** - Validation errors with redirect back
 - **serverError.js** - Error modal in dev, graceful redirect in prod
+- **notFound.js** - 404 status pages
+- **forbidden.js** - 403 status pages
 
 ## Architecture
 
@@ -499,7 +571,12 @@ module.exports.inertia = {
   // History encryption settings
   history: {
     encrypt: false
-  }
+  },
+
+  // Production status page component.
+  // Set to false to keep classic Sails EJS error views.
+  errorPage: 'error',
+  errorStatuses: [403, 404, 500, 503]
 }
 ```
 

--- a/packages/inertia-sails/index.js
+++ b/packages/inertia-sails/index.js
@@ -119,6 +119,8 @@ module.exports = function defineInertiaHook(sails) {
     defaults: {
       inertia: {
         rootView: 'app',
+        errorPage: 'error',
+        errorStatuses: [403, 404, 500, 503],
         // Auto-version from Shipwright manifest for cache busting
         // Override in config/inertia.js if needed
         version: () => getManifestVersion(),
@@ -716,17 +718,31 @@ module.exports = function defineInertiaHook(sails) {
     },
 
     /**
-     * Handle server error responses for Inertia.js
-     * For Inertia requests in development, displays a styled error modal with stack trace.
-     * In production, redirects back with a flash error message.
+     * Handle 500-level server errors for Inertia.js.
+     * In development, HTML responses render Youch. In production, configured
+     * Inertia apps can render the shared error page.
      * @docs https://docs.sailscasts.com/boring-stack/error-handling
      * @param {Request} req - The request object
      * @param {Response} res - The response object
      * @param {ErrorLike} [error] - Optional error data or Error object
-     * @returns {*} - Response (HTML modal for dev Inertia, redirect for prod)
+     * @returns {*} - Response
      */
     handleServerError(req, res, error) {
       return handleServerError(req, res, error)
+    },
+
+    /**
+     * Handle application status/error pages for Inertia.js.
+     * In development, 500-level HTML responses use Youch. In production,
+     * configured Inertia apps can render an Inertia status page.
+     * @docs https://docs.sailscasts.com/boring-stack/error-handling
+     * @param {Request} req - The request object
+     * @param {Response} res - The response object
+     * @param {{ statusCode?: number, error?: ErrorLike|string|Record<string, any>|null, page?: string }} [options] - Error page options
+     * @returns {*} - Response
+     */
+    handleErrorPage(req, res, options) {
+      return handleServerError.handleErrorPage(req, res, options)
     },
 
     /**

--- a/packages/inertia-sails/lib/responses/server-error.js
+++ b/packages/inertia-sails/lib/responses/server-error.js
@@ -1,323 +1,457 @@
+const render = require('../render')
+const { INERTIA } = require('../helpers/inertia-headers')
+
 /**
  * @typedef {import('../types').InertiaRequest} InertiaRequest
  * @typedef {import('../types').InertiaResponse} InertiaResponse
- * @typedef {import('../types').ErrorHtmlData} ErrorHtmlData
- * @typedef {{ message?: string, stack?: string, name?: string }} ErrorLike
+ * @typedef {{ message?: string, stack?: string, name?: string, status?: number, statusCode?: number }} ErrorLike
+ * @typedef {{ statusCode?: number, error?: ErrorLike|string|Record<string, any>|null, page?: string }} ErrorPageOptions
  */
+
+const DEFAULT_ERROR_STATUSES = [403, 404, 500, 503]
+
+/** @type {Record<number, { title: string, message: string }>} */
+const STATUS_TEXT = {
+  403: {
+    title: 'Forbidden',
+    message: 'You do not have permission to access this page.'
+  },
+  404: {
+    title: 'Page not found',
+    message: 'The page you are looking for could not be found.'
+  },
+  500: {
+    title: 'Server error',
+    message: 'Something went wrong on our end.'
+  },
+  503: {
+    title: 'Service unavailable',
+    message: 'The service is temporarily unavailable.'
+  }
+}
+
+const SECRET_PATTERN =
+  /authorization|cookie|csrf|xsrf|token|secret|password|passwd|session/i
 
 /**
- * Server Error Response for Inertia.js
- *
- * For Inertia requests, this sends a properly formatted error response that
- * triggers the Inertia error modal in development mode. In production, it
- * returns a generic error page.
- *
- * The error modal is a built-in Inertia.js feature that displays server errors
- * in a modal overlay during development, allowing developers to see stack traces
- * without losing their page state.
- *
- * @param {InertiaRequest} req - Express/Sails request object
- * @param {InertiaResponse} res - Express/Sails response object
- * @param {ErrorLike} [error] - Optional error data or Error object
- * @returns {*} - Response
- *
- * @example
- * // In an action
- * return sails.inertia.handleServerError(req, res, new Error('Something went wrong'))
- *
- * @example
- * // Using as a response type
- * exits: {
- *   serverError: {
- *     responseType: 'serverError'
- *   }
- * }
+ * @param {ErrorLike|string|Record<string, any>|null|undefined} error
+ * @param {number} fallbackStatusCode
+ * @returns {number}
  */
-module.exports = function handleServerError(req, res, error) {
-  const sails = req._sails
-  const statusCode = 500
-  const isInertiaRequest = req.header?.('X-Inertia')
-  const isDevelopment = process.env.NODE_ENV !== 'production'
+function resolveStatusCode(error, fallbackStatusCode) {
+  const statusCode =
+    typeof error === 'object' && error
+      ? Number(error.statusCode || error.status)
+      : Number.NaN
 
-  // Log the error
-  if (error) {
-    sails.log.error('Server error:', error)
-  }
+  return Number.isInteger(statusCode) && statusCode >= 400 && statusCode <= 599
+    ? statusCode
+    : fallbackStatusCode
+}
 
-  // For Inertia requests in development, send HTML that Inertia displays in a modal
-  if (isInertiaRequest && isDevelopment) {
-    const errorMessage = error?.message || 'Internal Server Error'
-    const errorStack = error?.stack || ''
-    const errorName = error?.name || 'Error'
-
-    // Build an HTML error page that Inertia will display in a modal
-    const html = buildErrorHtml({
-      statusCode,
-      errorName,
-      errorMessage,
-      errorStack,
-      url: req.url || '/',
-      method: req.method || 'GET'
-    })
-
-    res.status(statusCode)
-    res.type('text/html')
-    return res.send(html)
-  }
-
-  // For Inertia requests in production, redirect to error page with flash
-  if (isInertiaRequest) {
-    sails.inertia.flash(
-      'error',
-      'An unexpected error occurred. Please try again.'
-    )
-    return res.redirect(303, req.get('Referrer') || '/')
-  }
-
-  // For non-Inertia requests, use the standard Sails error view
-  res.status(statusCode)
-
-  // If there's a 500 view, render it
-  return res.view(
-    '500',
-    {
-      error: isDevelopment ? error : null
-    },
-    /**
-     * @param {Error|null} err
-     * @param {string} html
-     */
-    (err, html) => {
-      if (err) {
-        // If view doesn't exist, send a basic response
-        if (isDevelopment && error) {
-          return res.send(`<pre>${error.stack || error.message}</pre>`)
-        }
-        return res.send('Internal Server Error')
-      }
-      return res.send(html)
+/**
+ * @param {number} statusCode
+ * @returns {{ title: string, message: string }}
+ */
+function getStatusText(statusCode) {
+  return (
+    STATUS_TEXT[statusCode] || {
+      title: 'Error',
+      message: 'Something went wrong.'
     }
   )
 }
 
 /**
- * Build an HTML error page for the Inertia modal
- * @param {ErrorHtmlData} data
- * @returns {string}
+ * @param {InertiaRequest} req
+ * @returns {boolean}
  */
-function buildErrorHtml({
-  statusCode,
-  errorName,
-  errorMessage,
-  errorStack,
-  url,
-  method
-}) {
-  const escapedMessage = escapeHtml(errorMessage)
-  const escapedStack = escapeHtml(errorStack)
-  const escapedUrl = escapeHtml(url)
-  const escapedMethod = escapeHtml(method)
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${statusCode} - ${escapedMessage}</title>
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-    body {
-      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: #1a1a2e;
-      color: #e0e0e0;
-      padding: 2rem;
-      min-height: 100vh;
-    }
-    .container {
-      max-width: 900px;
-      margin: 0 auto;
-    }
-    .header {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 2rem;
-      padding-bottom: 1rem;
-      border-bottom: 1px solid #333;
-    }
-    .status-code {
-      font-size: 3rem;
-      font-weight: 700;
-      color: #ef4444;
-    }
-    .error-type {
-      font-size: 0.875rem;
-      color: #9ca3af;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-    .error-name {
-      font-size: 1.5rem;
-      font-weight: 600;
-      color: #f87171;
-    }
-    .request-info {
-      background: #16213e;
-      padding: 1rem;
-      border-radius: 0.5rem;
-      margin-bottom: 1.5rem;
-      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 0.875rem;
-    }
-    .request-method {
-      color: #60a5fa;
-      font-weight: 600;
-    }
-    .request-url {
-      color: #a5b4fc;
-    }
-    .message {
-      background: #1e1e3f;
-      padding: 1.5rem;
-      border-radius: 0.5rem;
-      margin-bottom: 1.5rem;
-      border-left: 4px solid #ef4444;
-    }
-    .message-title {
-      font-size: 0.75rem;
-      color: #9ca3af;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.5rem;
-    }
-    .message-text {
-      font-size: 1.125rem;
-      color: #fca5a5;
-      word-break: break-word;
-    }
-    .stack-trace {
-      background: #0f0f1a;
-      padding: 1.5rem;
-      border-radius: 0.5rem;
-      overflow-x: auto;
-    }
-    .stack-title {
-      font-size: 0.75rem;
-      color: #9ca3af;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 1rem;
-    }
-    .stack-content {
-      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-      font-size: 0.8125rem;
-      line-height: 1.6;
-      white-space: pre-wrap;
-      color: #a1a1aa;
-    }
-    .stack-content .at-line {
-      color: #6b7280;
-    }
-    .stack-content .file-path {
-      color: #60a5fa;
-    }
-    .footer {
-      margin-top: 2rem;
-      padding-top: 1rem;
-      border-top: 1px solid #333;
-      font-size: 0.75rem;
-      color: #6b7280;
-    }
-    .footer a {
-      color: #60a5fa;
-      text-decoration: none;
-    }
-    .footer a:hover {
-      text-decoration: underline;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <span class="status-code">${statusCode}</span>
-      <div>
-        <div class="error-type">Server Error</div>
-        <div class="error-name">${errorName}</div>
-      </div>
-    </div>
-
-    <div class="request-info">
-      <span class="request-method">${escapedMethod}</span>
-      <span class="request-url">${escapedUrl}</span>
-    </div>
-
-    <div class="message">
-      <div class="message-title">Error Message</div>
-      <div class="message-text">${escapedMessage}</div>
-    </div>
-
-    ${
-      escapedStack
-        ? `
-    <div class="stack-trace">
-      <div class="stack-title">Stack Trace</div>
-      <div class="stack-content">${formatStackTrace(escapedStack)}</div>
-    </div>
-    `
-        : ''
-    }
-
-    <div class="footer">
-      <p>This error page is only shown in development mode.</p>
-      <p>Powered by <a href="https://docs.sailscasts.com/boring-stack">The Boring JavaScript Stack</a></p>
-    </div>
-  </div>
-</body>
-</html>`
+function isInertiaRequest(req) {
+  return Boolean(req.get?.(INERTIA) || req.header?.(INERTIA))
 }
 
 /**
- * Format stack trace with syntax highlighting
- * @param {string} stack
+ * @param {InertiaRequest} req
+ * @returns {boolean}
+ */
+function wantsJson(req) {
+  if (isInertiaRequest(req)) {
+    return false
+  }
+
+  const request = /** @type {any} */ (req)
+  if (request.wantsJSON) {
+    return true
+  }
+
+  const accept = String(
+    req.get?.('Accept') || req.header?.('Accept') || req.headers?.accept || ''
+  ).toLowerCase()
+
+  return accept.includes('application/json') && !accept.includes('text/html')
+}
+
+/**
+ * @param {any} value
+ * @param {number} [depth]
+ * @returns {any}
+ */
+function sanitizeValue(value, depth = 0) {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 500 ? `${value.slice(0, 500)}...` : value
+  }
+
+  if (typeof value !== 'object') {
+    return value
+  }
+
+  if (depth >= 3) {
+    return '[object]'
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map((entry) => sanitizeValue(entry, depth + 1))
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      SECRET_PATTERN.test(key) ? '[redacted]' : sanitizeValue(entry, depth + 1)
+    ])
+  )
+}
+
+/**
+ * @param {Record<string, any>|undefined} record
+ * @returns {Record<string, any>}
+ */
+function sanitizeRecord(record) {
+  return sanitizeValue(record || {})
+}
+
+/**
+ * @param {Record<string, any>|undefined} record
+ * @returns {{ key: string, value: any }[]}
+ */
+function toMetadataRows(record) {
+  return Object.entries(sanitizeRecord(record)).map(([key, value]) => ({
+    key,
+    value
+  }))
+}
+
+/**
+ * @param {InertiaRequest} req
+ * @param {any} youch
+ * @returns {void}
+ */
+function addRequestMetadata(req, youch) {
+  const request = /** @type {any} */ (req)
+
+  youch.metadata.group('Sails request', {
+    request: [
+      { key: 'Method', value: req.method || 'GET' },
+      { key: 'URL', value: req.originalUrl || req.url || '/' }
+    ],
+    headers: toMetadataRows(req.headers),
+    params: toMetadataRows(request.params),
+    query: toMetadataRows(req.query),
+    body: toMetadataRows(request.body),
+    session: toMetadataRows(req.session)
+  })
+}
+
+/**
+ * @param {ErrorLike|string|Record<string, any>|null|undefined} error
+ * @param {number} statusCode
+ * @returns {Error}
+ */
+function normalizeError(error, statusCode) {
+  if (error instanceof Error) {
+    return error
+  }
+
+  const statusText = getStatusText(statusCode)
+  const message =
+    typeof error === 'string'
+      ? error
+      : typeof error === 'object' && error && typeof error.message === 'string'
+      ? error.message
+      : statusText.message
+
+  const normalizedError = new Error(message)
+  normalizedError.name =
+    typeof error === 'object' && error && typeof error.name === 'string'
+      ? error.name
+      : statusText.title
+
+  return normalizedError
+}
+
+/**
+ * Youch's theme switcher reads and writes localStorage. Inertia renders
+ * development error HTML inside a sandboxed iframe, where localStorage can
+ * throw a SecurityError. Swap Youch's direct localStorage calls for a small
+ * storage shim so the theme toggle still works in the Inertia error modal.
+ *
+ * @param {string} html
  * @returns {string}
  */
-function formatStackTrace(stack) {
-  return stack
-    .split('\n')
-    .map((line) => {
-      if (line.trim().startsWith('at ')) {
-        // Highlight file paths
-        return line
-          .replace(
-            /(\s+at\s+)([^\s]+)\s+\(([^)]+)\)/,
-            '<span class="at-line">$1</span>$2 (<span class="file-path">$3</span>)'
-          )
-          .replace(
-            /(\s+at\s+)([^\s(]+)$/,
-            '<span class="at-line">$1</span><span class="file-path">$2</span>'
-          )
+function makeYouchHtmlInertiaModalSafe(html) {
+  const storageShim = `<script id="inertia-sails-youch-storage">
+(function () {
+  var fallback = {}
+  window.__youchStorage = {
+    getItem: function (key) {
+      try {
+        return window.localStorage.getItem(key)
+      } catch (error) {
+        return Object.prototype.hasOwnProperty.call(fallback, key) ? fallback[key] : null
       }
-      return line
-    })
-    .join('\n')
+    },
+    setItem: function (key, value) {
+      try {
+        window.localStorage.setItem(key, value)
+      } catch (error) {
+        fallback[key] = String(value)
+      }
+    },
+    removeItem: function (key) {
+      try {
+        window.localStorage.removeItem(key)
+      } catch (error) {
+        delete fallback[key]
+      }
+    }
+  }
+})()
+</script>`
+
+  return html
+    .replaceAll('localStorage.', 'window.__youchStorage.')
+    .replace('</head>', `${storageShim}</head>`)
 }
 
 /**
- * Escape HTML special characters
- * @param {any} str
- * @returns {string}
+ * @param {InertiaRequest} req
+ * @param {Error} error
+ * @param {number} statusCode
+ * @returns {Promise<string>}
  */
-function escapeHtml(str) {
-  if (!str) return ''
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;')
+async function renderYouchHtml(req, error, statusCode) {
+  const { Youch } = await import('youch')
+  const youch = new Youch()
+
+  addRequestMetadata(req, youch)
+
+  const html = await youch.toHTML(error, {
+    title: `${statusCode} - ${getStatusText(statusCode).title}`,
+    request: {
+      url: req.originalUrl || req.url || '/',
+      method: req.method || 'GET',
+      headers: sanitizeRecord(req.headers)
+    }
+  })
+
+  return makeYouchHtmlInertiaModalSafe(html)
 }
+
+/**
+ * @param {InertiaRequest} req
+ * @param {InertiaResponse} res
+ * @param {number} statusCode
+ * @param {Error} error
+ * @returns {Promise<any>}
+ */
+async function sendDevelopmentHtml(req, res, statusCode, error) {
+  const html = await renderYouchHtml(req, error, statusCode)
+
+  res.status(statusCode)
+  res.type?.('text/html')
+  return res.send?.(html)
+}
+
+/**
+ * @param {InertiaResponse} res
+ * @param {number} statusCode
+ * @param {Error} error
+ * @param {boolean} isDevelopment
+ * @returns {*}
+ */
+function sendJsonError(res, statusCode, error, isDevelopment) {
+  const statusText = getStatusText(statusCode)
+  /** @type {{ error: { status: number, title: string, message: string, name?: string, stack?: string } }} */
+  const payload = {
+    error: {
+      status: statusCode,
+      title: statusText.title,
+      message: isDevelopment ? error.message : statusText.message
+    }
+  }
+
+  if (isDevelopment) {
+    payload.error.name = error.name
+    payload.error.stack = error.stack
+  }
+
+  return res.status?.(statusCode).json?.(payload)
+}
+
+/**
+ * @param {any} sails
+ * @returns {string|null}
+ */
+function getConfiguredErrorPage(sails) {
+  const configured = sails.config?.inertia?.errorPage
+
+  if (typeof configured === 'string') {
+    return configured
+  }
+
+  if (configured && typeof configured.page === 'string') {
+    return configured.page
+  }
+
+  return null
+}
+
+/**
+ * @param {any} sails
+ * @returns {number[]}
+ */
+function getConfiguredErrorStatuses(sails) {
+  const configured = sails.config?.inertia?.errorStatuses
+
+  if (!Array.isArray(configured)) {
+    return DEFAULT_ERROR_STATUSES
+  }
+
+  return configured
+    .map(Number)
+    .filter((statusCode) => Number.isInteger(statusCode))
+}
+
+/**
+ * @param {InertiaRequest} req
+ * @param {InertiaResponse} res
+ * @param {number} statusCode
+ * @param {string} page
+ * @returns {Promise<any>}
+ */
+function renderInertiaErrorPage(req, res, statusCode, page) {
+  const statusText = getStatusText(statusCode)
+
+  res.status?.(statusCode)
+  return render(req, res, {
+    page,
+    props: {
+      status: statusCode,
+      title: statusText.title,
+      message: statusText.message
+    }
+  })
+}
+
+/**
+ * @param {InertiaRequest} req
+ * @param {InertiaResponse} res
+ * @param {number} statusCode
+ * @param {Error} error
+ * @param {boolean} isDevelopment
+ * @returns {*}
+ */
+function renderSailsErrorView(req, res, statusCode, error, isDevelopment) {
+  const viewName = String(statusCode)
+
+  res.status?.(statusCode)
+  return res.view?.(
+    viewName,
+    {
+      error: isDevelopment && statusCode >= 500 ? error : null
+    },
+    /**
+     * @param {Error|null} viewError
+     * @param {string} html
+     * @returns {*}
+     */
+    (viewError, html) => {
+      if (viewError) {
+        return res.send?.(getStatusText(statusCode).message)
+      }
+
+      return res.send?.(html)
+    }
+  )
+}
+
+/**
+ * Render an application error response.
+ *
+ * In development, 500-level HTML responses use Youch. In production, apps can
+ * opt into Inertia status pages with `sails.config.inertia.errorPage`.
+ *
+ * @param {InertiaRequest} req
+ * @param {InertiaResponse} res
+ * @param {ErrorPageOptions} options
+ * @returns {Promise<any>|*}
+ */
+function handleErrorPage(req, res, options = {}) {
+  const sails = req._sails
+  const isDevelopment = process.env.NODE_ENV !== 'production'
+  const statusCode = resolveStatusCode(
+    options.error,
+    Number(options.statusCode || 500)
+  )
+  const error = normalizeError(options.error, statusCode)
+  const hasExplicitErrorPage = typeof options.page === 'string'
+
+  if (statusCode >= 500) {
+    sails.log?.error?.('Server error:', options.error || error)
+  }
+
+  if (wantsJson(req)) {
+    return sendJsonError(res, statusCode, error, isDevelopment)
+  }
+
+  if (isDevelopment && statusCode >= 500 && !hasExplicitErrorPage) {
+    return sendDevelopmentHtml(req, res, statusCode, error)
+  }
+
+  const errorPage = options.page || getConfiguredErrorPage(sails)
+  const errorStatuses = getConfiguredErrorStatuses(sails)
+
+  if (errorPage && errorStatuses.includes(statusCode)) {
+    return renderInertiaErrorPage(req, res, statusCode, errorPage)
+  }
+
+  if (isInertiaRequest(req)) {
+    sails.inertia.flash?.(
+      'error',
+      'An unexpected error occurred. Please try again.'
+    )
+    return res.redirect?.(303, req.get?.('Referrer') || '/')
+  }
+
+  return renderSailsErrorView(req, res, statusCode, error, isDevelopment)
+}
+
+/**
+ * Server Error Response for Inertia.js.
+ *
+ * @param {InertiaRequest} req - Express/Sails request object
+ * @param {InertiaResponse} res - Express/Sails response object
+ * @param {ErrorLike|string|Record<string, any>|null} [error] - Optional error data or Error object
+ * @returns {Promise<any>|*} - Response
+ */
+function handleServerError(req, res, error) {
+  return handleErrorPage(req, res, {
+    statusCode: 500,
+    error
+  })
+}
+
+module.exports = Object.assign(handleServerError, { handleErrorPage })

--- a/packages/inertia-sails/package-lock.json
+++ b/packages/inertia-sails/package-lock.json
@@ -1,22 +1,82 @@
 {
   "name": "inertia-sails",
-  "version": "0.1.4",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inertia-sails",
-      "version": "0.1.4",
+      "version": "1.5.0",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
-        "sails": ">=1"
+        "sails": ">=1",
+        "sails-flash": ">=0.0.1"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
     },
     "node_modules/@sailshq/lodash": {
       "version": "3.10.4",
       "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.4.tgz",
       "integrity": "sha512-YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q==",
       "peer": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -325,6 +385,15 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha512-2rcfELQt/ZMP+SM/pG8PyhJRaLKp+6Hk2IUBNkEit09X+vwn3QsAL3ZbYtxUn7NVPzbMTSLRDhqe0B/eh30RYA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -360,6 +429,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-parser": {
       "version": "1.4.4",
@@ -531,6 +606,15 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/escape-html": {
@@ -997,6 +1081,15 @@
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lodash": {
@@ -1649,6 +1742,16 @@
       "engines": {
         "node": ">= 0.10.0",
         "npm": ">= 1.4.0"
+      }
+    },
+    "node_modules/sails-flash": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/sails-flash/-/sails-flash-0.0.1.tgz",
+      "integrity": "sha512-8F9h8U/YFCnJR23Q6nR1I2TH2Si1dfQvPqO2YW0VoS15QleTWk2NTzfrAyNasGU182BRXNx+W4Tv33dc5cNJ+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "connect-flash": "^0.1.1"
       }
     },
     "node_modules/sails-generate": {
@@ -2376,14 +2479,77 @@
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
       }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
     }
   },
   "dependencies": {
+    "@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "requires": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "requires": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+          "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="
+        }
+      }
+    },
+    "@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="
+    },
     "@sailshq/lodash": {
       "version": "3.10.4",
       "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.4.tgz",
       "integrity": "sha512-YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q==",
       "peer": true
+    },
+    "@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="
+    },
+    "@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -2645,6 +2811,12 @@
         "utils-merge": "1.0.1"
       }
     },
+    "connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha512-2rcfELQt/ZMP+SM/pG8PyhJRaLKp+6Hk2IUBNkEit09X+vwn3QsAL3ZbYtxUn7NVPzbMTSLRDhqe0B/eh30RYA==",
+      "peer": true
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -2673,6 +2845,11 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "peer": true
+    },
+    "cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
     },
     "cookie-parser": {
       "version": "1.4.4",
@@ -2813,6 +2990,11 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "peer": true
+    },
+    "error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3223,6 +3405,11 @@
       "requires": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "lodash": {
       "version": "4.17.21",
@@ -3774,6 +3961,15 @@
         "uid-safe": "2.1.5",
         "vary": "1.1.2",
         "whelk": "^6.0.1"
+      }
+    },
+    "sails-flash": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/sails-flash/-/sails-flash-0.0.1.tgz",
+      "integrity": "sha512-8F9h8U/YFCnJR23Q6nR1I2TH2Si1dfQvPqO2YW0VoS15QleTWk2NTzfrAyNasGU182BRXNx+W4Tv33dc5cNJ+A==",
+      "peer": true,
+      "requires": {
+        "connect-flash": "^0.1.1"
       }
     },
     "sails-generate": {
@@ -4391,6 +4587,27 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
+      }
+    },
+    "youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "requires": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "requires": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/packages/inertia-sails/package.json
+++ b/packages/inertia-sails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inertia-sails",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "The Sails adapter for Inertia.",
   "main": "index.js",
   "sails": {
@@ -30,5 +30,7 @@
     "url": "https://github.com/sailscastshq/boring-stack/issues"
   },
   "homepage": "https://github.com/sailscastshq/boring-stack/tree/main/inertia-sails#readme",
-  "devDependencies": {}
+  "dependencies": {
+    "youch": "^4.1.1"
+  }
 }

--- a/packages/inertia-sails/tests/server-error.test.js
+++ b/packages/inertia-sails/tests/server-error.test.js
@@ -1,0 +1,283 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+const handleServerError = require('../lib/responses/server-error')
+const { INERTIA } = require('../lib/helpers/inertia-headers')
+
+/**
+ * @param {Object} [options]
+ * @param {Record<string, any>} [options.headers]
+ * @param {Record<string, any>} [options.inertiaConfig]
+ * @returns {any}
+ */
+function createRequest({ headers = {}, inertiaConfig = {} } = {}) {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  )
+
+  return {
+    method: 'GET',
+    url: '/broken',
+    originalUrl: '/broken?tab=settings',
+    query: { tab: 'settings' },
+    headers: normalizedHeaders,
+    params: { slug: 'broken' },
+    body: { email: 'person@example.com', password: 'secret' },
+    session: { userId: 10, csrfToken: 'session-secret' },
+    /**
+     * @param {string} header
+     * @returns {any}
+     */
+    get(header) {
+      return normalizedHeaders[header.toLowerCase()]
+    },
+    /**
+     * @param {string} header
+     * @returns {any}
+     */
+    header(header) {
+      return normalizedHeaders[header.toLowerCase()]
+    },
+    _sails: {
+      config: {
+        inertia: {
+          rootView: 'app',
+          version: 'test-version',
+          errorPage: 'error',
+          errorStatuses: [403, 404, 500, 503],
+          ...inertiaConfig
+        }
+      },
+      log: {
+        error() {}
+      },
+      inertia: {
+        flash() {},
+        getLocals() {
+          return {}
+        },
+        getShared() {
+          return {}
+        },
+        shouldClearHistory() {
+          return false
+        },
+        shouldEncryptHistory() {
+          return false
+        },
+        consumePreserveFragment() {
+          return false
+        },
+        consumeFlash() {
+          return {}
+        }
+      }
+    }
+  }
+}
+
+function createResponse() {
+  /** @type {Record<string, any>} */
+  const headers = {}
+
+  return {
+    headers,
+    statusCode: /** @type {number|null} */ (null),
+    body: /** @type {any} */ (null),
+    typeName: /** @type {string|null} */ (null),
+    viewName: /** @type {string|null} */ (null),
+    viewData: /** @type {any} */ (null),
+    redirectArgs: /** @type {any[]|null} */ (null),
+    /**
+     * @param {string} header
+     * @param {any} value
+     * @returns {any}
+     */
+    set(header, value) {
+      this.headers[header] = value
+      return this
+    },
+    /**
+     * @param {number} statusCode
+     * @returns {any}
+     */
+    status(statusCode) {
+      this.statusCode = statusCode
+      return this
+    },
+    /**
+     * @param {string} typeName
+     * @returns {any}
+     */
+    type(typeName) {
+      this.typeName = typeName
+      return this
+    },
+    /**
+     * @param {any} body
+     * @returns {any}
+     */
+    send(body) {
+      this.body = body
+      return this
+    },
+    /**
+     * @param {any} body
+     * @returns {any}
+     */
+    json(body) {
+      this.body = body
+      return this
+    },
+    /**
+     * @param {...any} args
+     * @returns {any}
+     */
+    redirect(...args) {
+      this.redirectArgs = args
+      return this
+    },
+    /**
+     * @param {string} viewName
+     * @param {any} viewData
+     * @returns {any}
+     */
+    view(viewName, viewData) {
+      this.viewName = viewName
+      this.viewData = viewData
+      return this
+    }
+  }
+}
+
+/**
+ * @param {string} value
+ * @param {() => Promise<void>} callback
+ */
+async function withNodeEnv(value, callback) {
+  const previousValue = process.env.NODE_ENV
+  process.env.NODE_ENV = value
+
+  try {
+    await callback()
+  } finally {
+    process.env.NODE_ENV = previousValue
+  }
+}
+
+describe('server error handling', function () {
+  it('renders Youch HTML for development server errors', async function () {
+    await withNodeEnv('development', async function () {
+      const authToken = ['super', 'secret', 'token'].join('-')
+      const sessionToken = ['session', 'secret'].join('-')
+      const req = createRequest({
+        headers: {
+          accept: 'text/html',
+          authorization: `Bearer ${authToken}`,
+          cookie: `sails.sid=${sessionToken}`
+        }
+      })
+      const res = createResponse()
+
+      await handleServerError(req, res, new Error('Boom from server action'))
+
+      assert.equal(res.statusCode, 500)
+      assert.equal(res.typeName, 'text/html')
+      assert.match(res.body, /Boom from server action/)
+      assert.match(res.body, /Sails request/)
+      assert.match(res.body, /window\.__youchStorage/)
+      assert.equal(
+        res.body.includes("localStorage.getItem('youch-theme')"),
+        false
+      )
+      assert.equal(res.body.includes(authToken), false)
+      assert.equal(res.body.includes(sessionToken), false)
+    })
+  })
+
+  it('renders the configured Inertia error page in production', async function () {
+    await withNodeEnv('production', async function () {
+      const req = createRequest({
+        headers: {
+          [INERTIA]: 'true',
+          accept: 'text/html'
+        }
+      })
+      const res = createResponse()
+
+      await handleServerError(req, res, new Error('Hidden production failure'))
+
+      assert.equal(res.statusCode, 500)
+      assert.equal(res.headers[INERTIA], true)
+      assert.equal(res.body.component, 'error')
+      assert.equal(res.body.props.status, 500)
+      assert.equal(res.body.props.title, 'Server error')
+      assert.equal(res.body.props.message, 'Something went wrong on our end.')
+      assert.equal(res.body.props.message.includes('Hidden production'), false)
+    })
+  })
+
+  it('allows explicit error pages to be previewed in development', async function () {
+    await withNodeEnv('development', async function () {
+      const req = createRequest({
+        headers: {
+          accept: 'text/html'
+        }
+      })
+      const res = createResponse()
+
+      await handleServerError.handleErrorPage(req, res, {
+        statusCode: 500,
+        page: 'error'
+      })
+
+      assert.equal(res.statusCode, 500)
+      assert.equal(res.typeName, null)
+      assert.equal(res.viewName, 'app')
+      assert.equal(res.viewData.page.component, 'error')
+      assert.equal(res.viewData.page.props.status, 500)
+      assert.equal(res.viewData.page.props.title, 'Server error')
+    })
+  })
+
+  it('returns JSON errors for JSON requests', async function () {
+    await withNodeEnv('production', async function () {
+      const req = createRequest({
+        headers: {
+          accept: 'application/json'
+        }
+      })
+      const res = createResponse()
+
+      await handleServerError.handleErrorPage(req, res, { statusCode: 404 })
+
+      assert.equal(res.statusCode, 404)
+      assert.deepEqual(res.body, {
+        error: {
+          status: 404,
+          title: 'Page not found',
+          message: 'The page you are looking for could not be found.'
+        }
+      })
+    })
+  })
+
+  it('falls back to Sails error views when the Inertia error page is disabled', async function () {
+    await withNodeEnv('production', async function () {
+      const req = createRequest({
+        headers: {
+          accept: 'text/html'
+        },
+        inertiaConfig: {
+          errorPage: false
+        }
+      })
+      const res = createResponse()
+
+      await handleServerError.handleErrorPage(req, res, { statusCode: 404 })
+
+      assert.equal(res.statusCode, 404)
+      assert.equal(res.viewName, '404')
+      assert.equal(res.viewData.error, null)
+    })
+  })
+})

--- a/skills/inertia/rules/error-handling.md
+++ b/skills/inertia/rules/error-handling.md
@@ -16,13 +16,18 @@ See [forms-and-validation.md](forms-and-validation.md) for the complete validati
 3. Inertia middleware shares errors as `errors` prop on next page load
 4. `useForm` makes them available as `form.errors.fieldName`
 
-## Server Errors (500)
+## Status And Server Errors
 
-The `inertia-sails` package includes a `serverError` response handler that behaves differently based on the environment and request type.
+The `inertia-sails` package includes `handleErrorPage()` and
+`handleServerError()` helpers that behave differently based on the environment,
+request type, and app configuration.
 
-### Development + Inertia Request
+### Development
 
-In development mode, server errors are displayed in the **Inertia error modal** -- a styled HTML overlay that shows the error name, message, stack trace, and request details. This lets you debug without losing your page state.
+In development mode, 500-level HTML errors are rendered with **Youch**. For
+Inertia visits, the client displays that HTML in the Inertia error modal, so the
+developer gets source frames, stack traces, and sanitized request metadata
+without losing the current page.
 
 ```
 ┌─────────────────────────────────────┐
@@ -41,31 +46,82 @@ In development mode, server errors are displayed in the **Inertia error modal** 
 └─────────────────────────────────────┘
 ```
 
-### Production + Inertia Request
+### Production
 
-In production, server errors:
-
-1. Flash a generic error message
-2. Redirect back to the Referrer URL with 303
+In production, `inertia-sails` renders the configured Inertia status page for
+`403`, `404`, `500`, and `503` responses by default:
 
 ```js
-// What happens internally:
-sails.inertia.flash('error', 'An unexpected error occurred. Please try again.')
-res.redirect(303, req.get('Referrer') || '/')
+// config/inertia.js
+module.exports.inertia = {
+  errorPage: 'error',
+  errorStatuses: [403, 404, 500, 503]
+}
 ```
 
-### Non-Inertia Requests
+The client must ship the page component:
 
-For non-Inertia requests (direct browser visits, API calls), the standard Sails error view (`views/500.ejs`) is rendered.
+```vue
+<!-- assets/js/pages/error.vue -->
+<script setup>
+import { Head, Link } from '@inertiajs/vue3'
 
-## Using `responseType: 'serverError'`
+defineProps({
+  status: Number,
+  title: String,
+  message: String
+})
+</script>
 
-Set up the server error response in your custom response file:
+<template>
+  <Head :title="`${status} ${title}`" />
+  <main>
+    <p>Status {{ status }}</p>
+    <h1>{{ title }}</h1>
+    <p>{{ message }}</p>
+    <Link href="/">Go home</Link>
+  </main>
+</template>
+```
+
+Hybrid apps that still want Sails' EJS `views/404.ejs` and `views/500.ejs`
+can opt out:
+
+```js
+module.exports.inertia = {
+  errorPage: false
+}
+```
+
+### JSON Requests
+
+JSON requests receive JSON status payloads instead of HTML or Inertia pages.
+
+## Response Files
+
+Wire Sails' built-in response names into `inertia-sails` so framework-level
+403/404/500 responses all use the same policy:
 
 ```js
 // api/responses/serverError.js
 module.exports = function serverError(data) {
   return this.req._sails.inertia.handleServerError(this.req, this.res, data)
+}
+
+// api/responses/notFound.js
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}
+
+// api/responses/forbidden.js
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
 }
 ```
 
@@ -95,20 +151,13 @@ fn: async function ({ teamId }) {
 }
 ```
 
-### Custom Error Pages
+### Custom Error Page Names
 
-For 404 errors, create a dedicated page:
+If an app wants a different component name, configure it:
 
 ```js
-// api/controllers/not-found.js (catch-all route)
-module.exports = {
-  exits: {
-    success: { responseType: 'inertia' }
-  },
-  fn: async function () {
-    this.res.status(404)
-    return { page: 'errors/404' }
-  }
+module.exports.inertia = {
+  errorPage: 'errors/status'
 }
 ```
 

--- a/skills/sails/rules/responses.md
+++ b/skills/sails/rules/responses.md
@@ -7,7 +7,7 @@ metadata:
 
 # Responses
 
-Custom responses in `api/responses/` define how actions communicate results to the client. The Boring Stack uses four main response types for Inertia.js integration.
+Custom responses in `api/responses/` define how actions communicate results to the client. The Boring Stack uses Inertia-aware response types for pages, validation, redirects, and status pages.
 
 ## Response Files
 
@@ -16,7 +16,9 @@ api/responses/
 ├── inertia.js          ← Renders an Inertia page
 ├── inertia-redirect.js ← 409 full page reload (for stale once() data)
 ├── badRequest.js       ← Validation errors → session → redirect back
-└── serverError.js      ← Error handling (dev modal or production flash)
+├── serverError.js      ← 500 handling with Youch in dev, status page in prod
+├── notFound.js         ← 404 status page
+└── forbidden.js        ← 403 status page
 ```
 
 ## `inertia.js` -- Render a Page
@@ -111,25 +113,45 @@ problems: [{ login: 'Wrong email/password combination.' }]
 // → form.errors.login = 'Wrong email/password combination.'
 ```
 
-## `serverError.js` -- Error Handling
+## `serverError.js`, `notFound.js`, `forbidden.js` -- Error Handling
 
 ```js
 // api/responses/serverError.js
 module.exports = function serverError(data) {
   return this.req._sails.inertia.handleServerError(this.req, this.res, data)
 }
+
+// api/responses/notFound.js
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}
+
+// api/responses/forbidden.js
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}
 ```
 
-**In development** (Inertia request): Shows a styled error modal with the error name, message, stack trace, and request details.
+**In development**: 500-level HTML responses render a Youch error page. Inertia visits show that page in the Inertia development modal.
 
-**In production** (Inertia request): Flashes a generic error message and redirects back:
+**In production**: `403`, `404`, `500`, and `503` render the configured Inertia status page by default:
 
 ```js
-sails.inertia.flash('error', 'An unexpected error occurred. Please try again.')
-res.redirect(303, req.get('Referrer') || '/')
+// config/inertia.js
+module.exports.inertia = {
+  errorPage: 'error',
+  errorStatuses: [403, 404, 500, 503]
+}
 ```
 
-**Non-Inertia requests**: Renders the standard `views/500.ejs` view.
+Ship `assets/js/pages/error.{vue,jsx,svelte}` in the client. Hybrid apps that
+prefer `views/404.ejs` and `views/500.ejs` can set `errorPage: false`.
 
 ## Generating Response Files
 

--- a/templates/ascent-react/api/responses/forbidden.js
+++ b/templates/ascent-react/api/responses/forbidden.js
@@ -1,0 +1,6 @@
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}

--- a/templates/ascent-react/api/responses/notFound.js
+++ b/templates/ascent-react/api/responses/notFound.js
@@ -1,0 +1,6 @@
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}

--- a/templates/ascent-react/assets/js/pages/error.jsx
+++ b/templates/ascent-react/assets/js/pages/error.jsx
@@ -1,0 +1,41 @@
+import { Head, Link } from '@inertiajs/react'
+
+export default function ErrorPage({ status, title, message }) {
+  const homeHref = status === 404 ? '/' : '/dashboard'
+
+  return (
+    <>
+      <Head title={`${status} ${title} | Ascent`} />
+
+      <main className="flex min-h-screen items-center bg-white px-6 py-16 text-gray-950 dark:bg-gray-950 dark:text-white">
+        <section className="mx-auto w-full max-w-3xl">
+          <p className="mb-4 text-sm font-semibold text-brand-600 dark:text-brand-300">
+            Status {status}
+          </p>
+          <h1 className="max-w-2xl text-4xl font-bold text-gray-950 dark:text-white sm:text-5xl">
+            {title}
+          </h1>
+          <p className="mt-5 max-w-xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+            {message}
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              href={homeHref}
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-brand-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:focus:ring-brand-800"
+            >
+              Go home
+            </Link>
+            <button
+              type="button"
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-200 bg-white px-5 text-sm font-semibold text-gray-800 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+              onClick={() => window.history.back()}
+            >
+              Go back
+            </button>
+          </div>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/templates/ascent-react/package-lock.json
+++ b/templates/ascent-react/package-lock.json
@@ -15,7 +15,7 @@
         "@sailshq/socket.io-redis": "^6.1.2",
         "@simplewebauthn/browser": "^13.2.2",
         "@simplewebauthn/server": "^13.2.2",
-        "inertia-sails": "^1.4.1",
+        "inertia-sails": "^1.5.0",
         "nodemailer": "^7.0.10",
         "primeicons": "^7.0.0",
         "primereact": "^10.9.7",
@@ -538,6 +538,44 @@
         "node": ">=18"
       }
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
+    },
     "node_modules/@rsbuild/core": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-2.0.7.tgz",
@@ -1011,11 +1049,29 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -1929,6 +1985,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -2309,6 +2371,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -3255,10 +3326,13 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.4.1.tgz",
-      "integrity": "sha512-z+DfliI41vuDtDxo2A05I8JOwFA6h0wMd0XD9axm0POO1yIhqHOtwMwq+Cs8X/zrFtAmAVnXFgE2lmGGd9xfcg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.5.0.tgz",
+      "integrity": "sha512-oPsrlJi3JnBoSzWjqAboXJoNTbZvgpvk2dHdjoeX+eYMC/o2r7VwsSN3DuvRVXApAh2D5k63ZaOIu16/gxG/Uw==",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"
@@ -3540,6 +3614,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/laravel-precognition": {
@@ -7200,6 +7283,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/templates/ascent-react/package.json
+++ b/templates/ascent-react/package.json
@@ -19,7 +19,7 @@
     "@sailshq/socket.io-redis": "^6.1.2",
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/server": "^13.2.2",
-    "inertia-sails": "^1.4.1",
+    "inertia-sails": "^1.5.0",
     "nodemailer": "^7.0.10",
     "primeicons": "^7.0.0",
     "primereact": "^10.9.7",

--- a/templates/ascent-vue/api/responses/forbidden.js
+++ b/templates/ascent-vue/api/responses/forbidden.js
@@ -1,0 +1,6 @@
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}

--- a/templates/ascent-vue/api/responses/notFound.js
+++ b/templates/ascent-vue/api/responses/notFound.js
@@ -1,0 +1,6 @@
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}

--- a/templates/ascent-vue/assets/js/pages/error.vue
+++ b/templates/ascent-vue/assets/js/pages/error.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3'
+
+const props = defineProps({
+  status: {
+    type: Number,
+    required: true
+  },
+  title: {
+    type: String,
+    required: true
+  },
+  message: {
+    type: String,
+    required: true
+  }
+})
+
+const homeHref = props.status === 404 ? '/' : '/dashboard'
+</script>
+
+<template>
+  <Head :title="`${status} ${title} | Ascent`" />
+
+  <main
+    class="flex min-h-screen items-center bg-white px-6 py-16 text-gray-950 dark:bg-gray-950 dark:text-white"
+  >
+    <section class="mx-auto w-full max-w-3xl">
+      <p class="mb-4 text-sm font-semibold text-brand-600 dark:text-brand-300">
+        Status {{ status }}
+      </p>
+      <h1
+        class="max-w-2xl text-4xl font-bold text-gray-950 sm:text-5xl dark:text-white"
+      >
+        {{ title }}
+      </h1>
+      <p
+        class="mt-5 max-w-xl text-lg leading-8 text-gray-600 dark:text-gray-300"
+      >
+        {{ message }}
+      </p>
+
+      <div class="mt-8 flex flex-wrap items-center gap-3">
+        <Link
+          :href="homeHref"
+          class="inline-flex min-h-11 items-center justify-center rounded-md bg-brand-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:focus:ring-brand-800"
+        >
+          Go home
+        </Link>
+        <button
+          type="button"
+          class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-200 bg-white px-5 text-sm font-semibold text-gray-800 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+          @click="history.back()"
+        >
+          Go back
+        </button>
+      </div>
+    </section>
+  </main>
+</template>

--- a/templates/ascent-vue/package-lock.json
+++ b/templates/ascent-vue/package-lock.json
@@ -16,7 +16,7 @@
         "@simplewebauthn/browser": "^13.2.0",
         "@simplewebauthn/server": "^13.2.1",
         "floating-vue": "^5.2.2",
-        "inertia-sails": "^1.4.1",
+        "inertia-sails": "^1.5.0",
         "nodemailer": "^7.0.10",
         "primeicons": "^7.0.0",
         "primevue": "^4.4.1",
@@ -497,6 +497,44 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
     },
     "node_modules/@primeuix/styled": {
       "version": "0.7.4",
@@ -1020,11 +1058,29 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -2201,6 +2257,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -2561,6 +2623,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -3502,10 +3573,13 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.4.1.tgz",
-      "integrity": "sha512-z+DfliI41vuDtDxo2A05I8JOwFA6h0wMd0XD9axm0POO1yIhqHOtwMwq+Cs8X/zrFtAmAVnXFgE2lmGGd9xfcg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.5.0.tgz",
+      "integrity": "sha512-oPsrlJi3JnBoSzWjqAboXJoNTbZvgpvk2dHdjoeX+eYMC/o2r7VwsSN3DuvRVXApAh2D5k63ZaOIu16/gxG/Uw==",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"
@@ -3739,6 +3813,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/laravel-precognition": {
@@ -7123,6 +7206,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/templates/ascent-vue/package.json
+++ b/templates/ascent-vue/package.json
@@ -20,7 +20,7 @@
     "@simplewebauthn/browser": "^13.2.0",
     "@simplewebauthn/server": "^13.2.1",
     "floating-vue": "^5.2.2",
-    "inertia-sails": "^1.4.1",
+    "inertia-sails": "^1.5.0",
     "nodemailer": "^7.0.10",
     "primeicons": "^7.0.0",
     "primevue": "^4.4.1",

--- a/templates/mellow-react/api/responses/forbidden.js
+++ b/templates/mellow-react/api/responses/forbidden.js
@@ -1,0 +1,6 @@
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}

--- a/templates/mellow-react/api/responses/notFound.js
+++ b/templates/mellow-react/api/responses/notFound.js
@@ -1,0 +1,6 @@
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}

--- a/templates/mellow-react/assets/js/components/InputBase.jsx
+++ b/templates/mellow-react/assets/js/components/InputBase.jsx
@@ -21,7 +21,7 @@ export default function InputBase({
         </span>
         <input
           id={id}
-          className={`placeholder:text-gray block min-h-12 w-full rounded-lg border bg-white py-3 pl-11 pr-10 text-base shadow-sm transition-colors placeholder:text-base focus:outline-none focus:ring-2 ${
+          className={`placeholder:text-gray min-h-12 block w-full rounded-lg border bg-white py-3 pl-11 pr-10 text-base shadow-sm transition-colors placeholder:text-base focus:outline-none focus:ring-2 ${
             error
               ? 'border-red-300 bg-red-50/40 text-red-950 focus:border-red-500 focus:ring-red-100'
               : 'border-gray/50 focus:ring-gray-100'

--- a/templates/mellow-react/assets/js/pages/error.jsx
+++ b/templates/mellow-react/assets/js/pages/error.jsx
@@ -1,0 +1,41 @@
+import { Head, Link } from '@inertiajs/react'
+
+export default function ErrorPage({ status, title, message }) {
+  const homeHref = status === 404 ? '/' : '/dashboard'
+
+  return (
+    <>
+      <Head title={`${status} ${title} | Mellow`} />
+
+      <main className="from-brand-50/10 flex min-h-screen items-center bg-gradient-to-b to-[#F9FAFB] px-6 py-16 text-black">
+        <section className="mx-auto w-full max-w-3xl">
+          <p className="text-brand mb-4 text-sm font-semibold">
+            Status {status}
+          </p>
+          <h1 className="max-w-2xl text-4xl font-semibold text-black sm:text-5xl">
+            {title}
+          </h1>
+          <p className="mt-5 max-w-xl text-lg leading-8 text-gray-600">
+            {message}
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              href={homeHref}
+              className="min-h-11 bg-brand hover:bg-brand-600 focus:ring-brand-100 inline-flex items-center justify-center rounded-md px-5 text-sm font-semibold text-white shadow-sm transition focus:outline-none focus:ring-2"
+            >
+              Go home
+            </Link>
+            <button
+              type="button"
+              className="min-h-11 inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-5 text-sm font-semibold text-black shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200"
+              onClick={() => window.history.back()}
+            >
+              Go back
+            </button>
+          </div>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/templates/mellow-react/package-lock.json
+++ b/templates/mellow-react/package-lock.json
@@ -12,7 +12,7 @@
         "@sailshq/connect-redis": "^6.1.3",
         "@sailshq/lodash": "^3.10.7",
         "@sailshq/socket.io-redis": "^6.1.2",
-        "inertia-sails": "^1.4.1",
+        "inertia-sails": "^1.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "sails": "^1.5.15",
@@ -243,6 +243,44 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
     },
     "node_modules/@rsbuild/core": {
       "version": "2.0.7",
@@ -682,11 +720,29 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -1623,6 +1679,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -1943,6 +2005,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -2800,10 +2871,13 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.4.1.tgz",
-      "integrity": "sha512-z+DfliI41vuDtDxo2A05I8JOwFA6h0wMd0XD9axm0POO1yIhqHOtwMwq+Cs8X/zrFtAmAVnXFgE2lmGGd9xfcg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.5.0.tgz",
+      "integrity": "sha512-oPsrlJi3JnBoSzWjqAboXJoNTbZvgpvk2dHdjoeX+eYMC/o2r7VwsSN3DuvRVXApAh2D5k63ZaOIu16/gxG/Uw==",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"
@@ -2989,6 +3063,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/laravel-precognition": {
@@ -5734,6 +5817,29 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/templates/mellow-react/package.json
+++ b/templates/mellow-react/package.json
@@ -9,7 +9,7 @@
     "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.7",
     "@sailshq/socket.io-redis": "^6.1.2",
-    "inertia-sails": "^1.4.1",
+    "inertia-sails": "^1.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "sails": "^1.5.15",

--- a/templates/mellow-svelte/api/responses/forbidden.js
+++ b/templates/mellow-svelte/api/responses/forbidden.js
@@ -1,0 +1,6 @@
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}

--- a/templates/mellow-svelte/api/responses/notFound.js
+++ b/templates/mellow-svelte/api/responses/notFound.js
@@ -1,0 +1,6 @@
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}

--- a/templates/mellow-svelte/assets/js/pages/error.svelte
+++ b/templates/mellow-svelte/assets/js/pages/error.svelte
@@ -1,0 +1,43 @@
+<script>
+  import { Link } from '@inertiajs/svelte'
+
+  export let status
+  export let title
+  export let message
+
+  $: homeHref = status === 404 ? '/' : '/dashboard'
+</script>
+
+<svelte:head>
+  <title>{status} {title} | Mellow</title>
+</svelte:head>
+
+<main
+  class="flex min-h-screen items-center bg-linear-to-b from-brand-50/10 to-[#F9FAFB] px-6 py-16 text-black"
+>
+  <section class="mx-auto w-full max-w-3xl">
+    <p class="mb-4 text-sm font-semibold text-brand">Status {status}</p>
+    <h1 class="max-w-2xl text-4xl font-semibold text-black sm:text-5xl">
+      {title}
+    </h1>
+    <p class="mt-5 max-w-xl text-lg leading-8 text-gray-600">
+      {message}
+    </p>
+
+    <div class="mt-8 flex flex-wrap items-center gap-3">
+      <Link
+        href={homeHref}
+        class="inline-flex min-h-11 items-center justify-center rounded-md bg-brand px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-100"
+      >
+        Go home
+      </Link>
+      <button
+        type="button"
+        class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-200 bg-white px-5 text-sm font-semibold text-black shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200"
+        on:click={() => history.back()}
+      >
+        Go back
+      </button>
+    </div>
+  </section>
+</main>

--- a/templates/mellow-svelte/package-lock.json
+++ b/templates/mellow-svelte/package-lock.json
@@ -12,7 +12,7 @@
         "@sailshq/connect-redis": "^6.1.3",
         "@sailshq/lodash": "^3.10.6",
         "@sailshq/socket.io-redis": "^6.1.2",
-        "inertia-sails": "^1.4.1",
+        "inertia-sails": "^1.5.0",
         "nodemailer": "^6.9.15",
         "sails": "^1.5.12",
         "sails-flash": "^0.0.1",
@@ -241,6 +241,44 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
     },
     "node_modules/@rsbuild/core": {
       "version": "2.0.7",
@@ -684,11 +722,29 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -1704,6 +1760,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -2061,6 +2123,15 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -3025,10 +3096,13 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.4.1.tgz",
-      "integrity": "sha512-z+DfliI41vuDtDxo2A05I8JOwFA6h0wMd0XD9axm0POO1yIhqHOtwMwq+Cs8X/zrFtAmAVnXFgE2lmGGd9xfcg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.5.0.tgz",
+      "integrity": "sha512-oPsrlJi3JnBoSzWjqAboXJoNTbZvgpvk2dHdjoeX+eYMC/o2r7VwsSN3DuvRVXApAh2D5k63ZaOIu16/gxG/Uw==",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"
@@ -3278,6 +3352,15 @@
       "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/laravel-precognition": {
@@ -6542,6 +6625,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     },
     "node_modules/zimmerframe": {

--- a/templates/mellow-svelte/package.json
+++ b/templates/mellow-svelte/package.json
@@ -9,7 +9,7 @@
     "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.6",
     "@sailshq/socket.io-redis": "^6.1.2",
-    "inertia-sails": "^1.4.1",
+    "inertia-sails": "^1.5.0",
     "nodemailer": "^6.9.15",
     "sails": "^1.5.12",
     "sails-flash": "^0.0.1",

--- a/templates/mellow-vue/api/responses/forbidden.js
+++ b/templates/mellow-vue/api/responses/forbidden.js
@@ -1,0 +1,6 @@
+module.exports = function forbidden(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 403,
+    error
+  })
+}

--- a/templates/mellow-vue/api/responses/notFound.js
+++ b/templates/mellow-vue/api/responses/notFound.js
@@ -1,0 +1,6 @@
+module.exports = function notFound(error) {
+  return this.req._sails.inertia.handleErrorPage(this.req, this.res, {
+    statusCode: 404,
+    error
+  })
+}

--- a/templates/mellow-vue/assets/js/components/InputBase.vue
+++ b/templates/mellow-vue/assets/js/components/InputBase.vue
@@ -43,7 +43,7 @@ function updateValue(event) {
       <input
         :id="id"
         :class="[
-          'placeholder:text-gray block min-h-12 w-full rounded-lg border bg-white py-3 pl-11 pr-10 text-base shadow-sm transition-colors placeholder:text-base focus:outline-none focus:ring-2',
+          'placeholder:text-gray min-h-12 block w-full rounded-lg border bg-white py-3 pl-11 pr-10 text-base shadow-sm transition-colors placeholder:text-base focus:outline-none focus:ring-2',
           error
             ? 'border-red-300 bg-red-50/40 text-red-950 focus:border-red-500 focus:ring-red-100'
             : 'border-gray/50 focus:ring-gray-100'

--- a/templates/mellow-vue/assets/js/pages/error.vue
+++ b/templates/mellow-vue/assets/js/pages/error.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3'
+
+const props = defineProps({
+  status: {
+    type: Number,
+    required: true
+  },
+  title: {
+    type: String,
+    required: true
+  },
+  message: {
+    type: String,
+    required: true
+  }
+})
+
+const homeHref = props.status === 404 ? '/' : '/dashboard'
+</script>
+
+<template>
+  <Head :title="`${status} ${title} | Mellow`" />
+
+  <main
+    class="from-brand-50/10 flex min-h-screen items-center bg-gradient-to-b to-[#F9FAFB] px-6 py-16 text-black"
+  >
+    <section class="mx-auto w-full max-w-3xl">
+      <p class="text-brand mb-4 text-sm font-semibold">Status {{ status }}</p>
+      <h1 class="max-w-2xl text-4xl font-semibold text-black sm:text-5xl">
+        {{ title }}
+      </h1>
+      <p class="mt-5 max-w-xl text-lg leading-8 text-gray-600">
+        {{ message }}
+      </p>
+
+      <div class="mt-8 flex flex-wrap items-center gap-3">
+        <Link
+          :href="homeHref"
+          class="min-h-11 bg-brand hover:bg-brand-600 focus:ring-brand-100 inline-flex items-center justify-center rounded-md px-5 text-sm font-semibold text-white shadow-sm transition focus:outline-none focus:ring-2"
+        >
+          Go home
+        </Link>
+        <button
+          type="button"
+          class="min-h-11 inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-5 text-sm font-semibold text-black shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200"
+          @click="history.back()"
+        >
+          Go back
+        </button>
+      </div>
+    </section>
+  </main>
+</template>

--- a/templates/mellow-vue/package-lock.json
+++ b/templates/mellow-vue/package-lock.json
@@ -12,7 +12,7 @@
         "@sailshq/connect-redis": "^6.1.3",
         "@sailshq/lodash": "^3.10.3",
         "@sailshq/socket.io-redis": "^6.1.2",
-        "inertia-sails": "^1.4.1",
+        "inertia-sails": "^1.5.0",
         "nodemailer": "^6.9.15",
         "sails": "^1.5.14",
         "sails-flash": "^0.0.1",
@@ -283,6 +283,44 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+      "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "license": "MIT"
     },
     "node_modules/@rsbuild/core": {
       "version": "2.0.7",
@@ -751,11 +789,29 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "license": "CC0-1.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -1908,6 +1964,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
@@ -2269,6 +2331,15 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -3203,10 +3274,13 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.4.1.tgz",
-      "integrity": "sha512-z+DfliI41vuDtDxo2A05I8JOwFA6h0wMd0XD9axm0POO1yIhqHOtwMwq+Cs8X/zrFtAmAVnXFgE2lmGGd9xfcg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.5.0.tgz",
+      "integrity": "sha512-oPsrlJi3JnBoSzWjqAboXJoNTbZvgpvk2dHdjoeX+eYMC/o2r7VwsSN3DuvRVXApAh2D5k63ZaOIu16/gxG/Uw==",
       "license": "MIT",
+      "dependencies": {
+        "youch": "^4.1.1"
+      },
       "peerDependencies": {
         "sails": ">=1",
         "sails-flash": ">=0.0.1"
@@ -3435,6 +3509,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/laravel-precognition": {
@@ -6734,6 +6817,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+      "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.6",
+        "@poppinss/dumper": "^0.7.0",
+        "@speed-highlight/core": "^1.2.14",
+        "cookie-es": "^3.0.1",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/templates/mellow-vue/package.json
+++ b/templates/mellow-vue/package.json
@@ -9,7 +9,7 @@
     "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.3",
     "@sailshq/socket.io-redis": "^6.1.2",
-    "inertia-sails": "^1.4.1",
+    "inertia-sails": "^1.5.0",
     "nodemailer": "^6.9.15",
     "sails": "^1.5.14",
     "sails-flash": "^0.0.1",


### PR DESCRIPTION
## What changed

- Adds `inertia-sails@1.5.0` rich error handling with Youch-powered development HTML, sanitized request metadata, JSON fallbacks, and configurable Inertia status pages.
- Ships branded `error` pages plus `notFound` and `forbidden` responses across the Vue, React, and Svelte templates.
- Updates template dependencies to the published `inertia-sails@^1.5.0`.
- Documents the new error-handling behavior in the package README and agent skills.

## Why

The Boring JavaScript Stack should make server-side failures pleasant to debug in development while keeping production errors branded, calm, and safe for users. This also aligns the stack with Inertia v3's error-handling story without requiring every app to hand-roll the same response plumbing.

## Notes

- Development 500-level HTML responses use Youch directly. Inertia displays those responses in its built-in development modal for XHR/Inertia failures.
- Youch request metadata redacts cookies, authorization headers, CSRF tokens, passwords, secrets, and session-looking values.
- Production 403, 404, 500, and 503 statuses render the configured `error` Inertia page by default.
- The tiny empty-frame flash in the upstream Inertia modal is tracked separately at inertiajs/inertia#3130.

## Validation

- `npm --workspace inertia-sails test`
- `npm run lint` in `templates/mellow-vue`
- `npm run lint` in `templates/mellow-react`
- `npm run lint` in `templates/mellow-svelte`
- `npm run lint` in `templates/ascent-vue`
- `npm run lint` in `templates/ascent-react`

Closes #198
