### PR TITLE
docs: teach testing skill browser artifacts

### DIFF
--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -34,6 +34,7 @@ Use this skill when:
 - Writing trials around `sails.helpers`, `get()` / `post()`, `visit()`, `auth`, `login`, `mailbox`, or `page`
 - Choosing between virtual transport and real HTTP transport
 - Keeping mail capture, datastore isolation, and browser setup calm and predictable
+- Debugging failed browser trials with Sounding's default URL/screenshot artifacts and opt-in traces/videos
 - Setting up CI around a Sounding-powered suite
 
 ## Sounding Mental Model

--- a/skills/testing/rules/e2e-testing.md
+++ b/skills/testing/rules/e2e-testing.md
@@ -38,6 +38,33 @@ When `{ browser: true }` is enabled, the trial context can include:
 - `browser`
 - Playwright-backed `expect()` behavior
 
+Failed browser-capable trials also keep useful evidence by default:
+
+- the current URL
+- `.tmp/sounding/artifacts/<trial-name>/<browser-project>/current-url.txt`
+- `.tmp/sounding/artifacts/<trial-name>/<browser-project>/screenshot.png`
+
+When a failure is flaky or timing-sensitive, scope heavier capture to that trial:
+
+```js
+test(
+  'checkout keeps the cart after refresh',
+  {
+    browser: {
+      artifacts: {
+        trace: true,
+        video: true
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/checkout')
+  }
+)
+```
+
+Keep trace and video opt-in unless the app has a deliberate CI artifact policy.
+
 ## Use browser-capable trials for the right things
 
 Good uses:

--- a/skills/testing/rules/test-configuration.md
+++ b/skills/testing/rules/test-configuration.md
@@ -70,6 +70,54 @@ Modes:
 
 Managed SQLite artifacts already default to `.tmp/db`, so most apps never need a `config/sounding.js` file at all.
 
+## Browser artifacts
+
+Browser failure artifacts default to:
+
+```js
+browser: {
+  artifacts: {
+    outputDir: '.tmp/sounding/artifacts',
+    screenshot: true,
+    currentUrl: true,
+    trace: false,
+    video: false,
+  },
+}
+```
+
+Use booleans for the common path:
+
+- `true` keeps the artifact when the trial fails
+- `false` disables it
+
+Use explicit modes only when needed:
+
+- `off`
+- `on-failure`
+- `on`
+
+Prefer turning trace or video on for one browser trial first:
+
+```js
+test(
+  'editor keeps draft state',
+  {
+    browser: {
+      artifacts: {
+        trace: true,
+        video: true
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/dashboard/editor')
+  }
+)
+```
+
+For CI, upload `.tmp/sounding/artifacts` after failed browser runs when the app needs browser evidence.
+
 ## Request transport defaults
 
 For non-browser trials, the calm default is:


### PR DESCRIPTION
Closes sailscastshq/sounding#39

## Summary
- update the Testing skill to mention Sounding browser failure artifacts
- add e2e guidance for URL and screenshot defaults
- add config guidance for trace and video opt-ins

## Verification
- npx prettier --config ./.prettierrc.js --check skills/testing/SKILL.md skills/testing/rules/e2e-testing.md skills/testing/rules/test-configuration.md
- git diff --check