### PR TITLE
docs: teach testing skill browser projects

### DIFF
--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -34,6 +34,7 @@ Use this skill when:
 - Writing trials around `sails.helpers`, `get()` / `post()`, `visit()`, `auth`, `login`, `mailbox`, or `page`
 - Choosing between virtual transport and real HTTP transport
 - Keeping mail capture, datastore isolation, and browser setup calm and predictable
+- Selecting named browser projects such as `desktop`, `mobile`, or `safari`
 - Debugging failed browser trials with Sounding's default URL/screenshot artifacts and opt-in traces/videos
 - Setting up CI around a Sounding-powered suite
 

--- a/skills/testing/rules/e2e-testing.md
+++ b/skills/testing/rules/e2e-testing.md
@@ -38,6 +38,30 @@ When `{ browser: true }` is enabled, the trial context can include:
 - `browser`
 - Playwright-backed `expect()` behavior
 
+Use named projects when the trial needs mobile or a specific browser engine:
+
+```js
+test(
+  'mobile nav opens the account menu',
+  { browser: 'mobile' },
+  async ({ page }) => {
+    await page.goto('/dashboard')
+  }
+)
+```
+
+Use the object form when the trial also needs artifacts or overrides:
+
+```js
+test(
+  'checkout works in WebKit',
+  { browser: { project: 'safari' } },
+  async ({ page }) => {
+    await page.goto('/checkout')
+  }
+)
+```
+
 Failed browser-capable trials also keep useful evidence by default:
 
 - the current URL

--- a/skills/testing/rules/test-configuration.md
+++ b/skills/testing/rules/test-configuration.md
@@ -70,6 +70,28 @@ Modes:
 
 Managed SQLite artifacts already default to `.tmp/db`, so most apps never need a `config/sounding.js` file at all.
 
+## Browser projects
+
+Browser trials default to the `desktop` project. Add named project objects when an app needs mobile or cross-browser coverage:
+
+```js
+browser: {
+  projects: {
+    desktop: {},
+    mobile: {
+      device: 'iPhone 13',
+    },
+    safari: {
+      type: 'webkit',
+    },
+  },
+  defaultProject: 'desktop',
+}
+```
+
+Prefer `browser: 'mobile'` in trials when selecting a project by name.
+Use `browser: { project: 'safari' }` when the same trial also needs artifacts, context options, or launch options.
+
 ## Browser artifacts
 
 Browser failure artifacts default to:


### PR DESCRIPTION
Closes sailscastshq/sounding#40

## Summary
- Update the testing skill to recognize Sounding browser project ergonomics.
- Teach `browser: "mobile"` as the lightest mobile browser trial API.
- Add configuration guidance for named browser projects under the Sounding config rules.

## Verification
- `npx prettier --config ./.prettierrc.js --check skills/testing/SKILL.md skills/testing/rules/e2e-testing.md skills/testing/rules/test-configuration.md`
- `git diff --check`